### PR TITLE
Ignored with the suffix slash of zpath when completion

### DIFF
--- a/core/completer.go
+++ b/core/completer.go
@@ -40,7 +40,7 @@ func argumentsCompleter(args []string, cmd *Cmd) []prompt.Suggest {
 	first := args[0]
 	switch first {
 	case "get", "ls", "create", "set", "delete":
-		p := args[1]
+		p := strings.TrimSuffix(args[1], "/")
 		if len(args) > 2 {
 			switch first {
 			case "create", "set":


### PR DESCRIPTION
So if I input `/huskar/service/`, it can also complete the zpath.